### PR TITLE
init ram with '-' instead of all zeroes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ The primary purpose of this emulator is to enable rapid prototyping and developm
 
 Instruction timings and hardware access times are _waaay_ off, so any profiling/benchmarking performed in the emulator won't be representative of the real hardware whatsoever.
 
+## Emulator Quirks
+
+- Instead of zeroing-out RAM, uninitialized RAM is set to the ASCII value corresponding to '-' (i.e: 45). This makes it easier to catch uninitialized memory bugs.
+
 ## Status
 
 - Core features

--- a/src/devices/ram.rs
+++ b/src/devices/ram.rs
@@ -19,7 +19,7 @@ impl Ram {
     /// size in bytes
     pub fn new(size: usize) -> Ram {
         Ram {
-            mem: vec![0u8; size],
+            mem: vec![b'-'; size], // non-zero value to make it easier to spot bugs
         }
     }
 


### PR DESCRIPTION
I toyed around with using `rand` to make it truly random, but it's _slow af_ to fill 32Mb of RAM with garbage (at least on my chromebook lol)