### PR TITLE
Fix IVT entry to account for PC offset

### DIFF
--- a/src/ts7200.rs
+++ b/src/ts7200.rs
@@ -79,7 +79,7 @@ impl Ts7200 {
         // e.g: SWI correspond to IVT entry 0x08, so to register a SWI handler,
         // write a function pointer to 0x28
         for addr in (0..0x20).step_by(0x04) {
-            bus.sdram.w32(addr, 0xe59f_f020).unwrap();
+            bus.sdram.w32(addr, 0xe59f_f018).unwrap();
         }
 
         // TODO: instantiate various hardware devices to HLE state


### PR DESCRIPTION
Due to pipelining, the value of PC is actually 8 bytes ahead of the address of the `LDR` instruction, so an offset of `0x18` is needed to load data `0x20` bytes ahead.