### PR TITLE
prevent 'overflow when adding duration to instant' on MacOS

### DIFF
--- a/src/devices/timer.rs
+++ b/src/devices/timer.rs
@@ -45,7 +45,8 @@ fn spawn_interrupter_thread(
         loop {
             let timeout = match next {
                 Some(next) => next.saturating_duration_since(Instant::now()),
-                None => Duration::from_secs((std::u32::MAX / 8) as _),
+                // XXX: Not technically correct, but this is a long enough time
+                None => Duration::from_secs(std::u32::MAX as _),
             };
 
             match rx.recv_timeout(timeout) {


### PR DESCRIPTION
On the head of `uart-intr`, I've been seeing the below exceptions related to the timer interrupt threads. For some reason, changing `std::u64::MAX` to `std::u32::MAX` stops the overflow, but I don't really know why.

This behaviour was only observed on my mac, not on the student.cs servers.

```sh
thread 'thread '<unnamed><unnamed>' panicked at '' panicked at 'overflow when adding duration to instantoverflow when adding duration to instant', ', src/libstd/time.rssrc/libstd/time.rs::358358::99

thread '<unnamed>' panicked at 'overflow when adding duration to instant', src/libstd/time.rs:358:9
stack backtrace:
   0:        0x1068f8845 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h8db83eca50336bdb
   1:        0x1069113bd - core::fmt::write::h1dd60e084b1878bd
   2:        0x1068f3a6b - std::io::Write::write_fmt::hff040ddf0c90252f
   3:        0x1068fa64a - std::panicking::default_hook::{{closure}}::h30e59e050073de11
   4:        0x1068fa34a - std::panicking::default_hook::h471dc4c16e17c6ba
   5:        0x1068fac9d - std::panicking::rust_panic_with_hook::h9acc441fb91822a7
   6:        0x1068fa862 - rust_begin_unwind
   7:        0x10691800f - core::panicking::panic_fmt::h9ba960080cb7e2bf
   8:        0x106917e9a - core::option::expect_failed::h07f27b600ea8cacc
   9:        0x1068f83f8 - <std::time::Instant as core::ops::arith::Add<core::time::Duration>>::add::h67194bdad8840740
  10:        0x106772260 - crossbeam_channel::channel::Receiver<T>::recv_timeout::h5d99f9bb21bbea77
  11:        0x10675109c - std::sys_common::backtrace::__rust_begin_short_backtrace::h6f4dd981c3669156
  12:        0x10677d7e8 - std::panicking::try::do_call::h4bbba1167843ff67
  13:        0x1068fdcbb - __rust_maybe_catch_panic
  14:        0x10676745f - core::ops::function::FnOnce::call_once{{vtable.shim}}::hc90e5a1d481e90fb
  15:        0x1068ee27e - <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::hd75e9f7809bd38c6
  16:        0x1068fd1fe - std::sys::unix::thread::Thread::new::thread_start::ha6b5445a5021ab98
  17:     0x7fff66ad62eb - _pthread_body
  18:     0x7fff66ad9249 - _pthread_start
stack backtrace:
   0:        0x1068f8845 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h8db83eca50336bdb
   1:        0x1069113bd - core::fmt::write::h1dd60e084b1878bd
   2:        0x1068f3a6b - std::io::Write::write_fmt::hff040ddf0c90252f
   3:        0x1068fa64a - std::panicking::default_hook::{{closure}}::h30e59e050073de11
   4:        0x1068fa34a - std::panicking::default_hook::h471dc4c16e17c6ba
   5:        0x1068fac9d - std::panicking::rust_panic_with_hook::h9acc441fb91822a7
   6:        0x1068fa862 - rust_begin_unwind
   7:        0x10691800f - core::panicking::panic_fmt::h9ba960080cb7e2bf
   8:        0x106917e9a - core::option::expect_failed::h07f27b600ea8cacc
   9:        0x1068f83f8 - <std::time::Instant as core::ops::arith::Add<core::time::Duration>>::add::h67194bdad8840740
  10:        0x106772260 - crossbeam_channel::channel::Receiver<T>::recv_timeout::h5d99f9bb21bbea77
  11:        0x10675109c - std::sys_common::backtrace::__rust_begin_short_backtrace::h6f4dd981c3669156
  12:        0x10677d7e8 - std::panicking::try::do_call::h4bbba1167843ff67
  13:        0x1068fdcbb - __rust_maybe_catch_panic
  14:        0x10676745f - core::ops::function::FnOnce::call_once{{vtable.shim}}::hc90e5a1d481e90fb
  15:        0x1068ee27e - <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::hd75e9f7809bd38c6
  16:        0x1068fd1fe - std::sys::unix::thread::Thread::new::thread_start::ha6b5445a5021ab98
  17:     0x7fff66ad62eb - _pthread_body
  18:     0x7fff66ad9249 - _pthread_start
stack backtrace:
   0:        0x1068f8845 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h8db83eca50336bdb
   1:        0x1069113bd - core::fmt::write::h1dd60e084b1878bd
   2:        0x1068f3a6b - std::io::Write::write_fmt::hff040ddf0c90252f
   3:        0x1068fa64a - std::panicking::default_hook::{{closure}}::h30e59e050073de11
   4:        0x1068fa34a - std::panicking::default_hook::h471dc4c16e17c6ba
   5:        0x1068fac9d - std::panicking::rust_panic_with_hook::h9acc441fb91822a7
   6:        0x1068fa862 - rust_begin_unwind
   7:        0x10691800f - core::panicking::panic_fmt::h9ba960080cb7e2bf
   8:        0x106917e9a - core::option::expect_failed::h07f27b600ea8cacc
   9:        0x1068f83f8 - <std::time::Instant as core::ops::arith::Add<core::time::Duration>>::add::h67194bdad8840740
  10:        0x106772260 - crossbeam_channel::channel::Receiver<T>::recv_timeout::h5d99f9bb21bbea77
  11:        0x10675109c - std::sys_common::backtrace::__rust_begin_short_backtrace::h6f4dd981c3669156
  12:        0x10677d7e8 - std::panicking::try::do_call::h4bbba1167843ff67
  13:        0x1068fdcbb - __rust_maybe_catch_panic
  14:        0x10676745f - core::ops::function::FnOnce::call_once{{vtable.shim}}::hc90e5a1d481e90fb
  15:        0x1068ee27e - <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::hd75e9f7809bd38c6
  16:        0x1068fd1fe - std::sys::unix::thread::Thread::new::thread_start::ha6b5445a5021ab98
  17:     0x7fff66ad62eb - _pthread_body
  18:     0x7fff66ad9249 - _pthread_start
dropped Some("uart1")
dropped Some("uart2")
```