### PR TITLE
Always drain interrupt bus and query vic in check_exception

### DIFF
--- a/src/ts7200.rs
+++ b/src/ts7200.rs
@@ -127,22 +127,25 @@ impl Ts7200 {
     }
 
     fn check_exception(&mut self, blocking: CheckException) {
-        let iter: Box<dyn Iterator<Item = (Interrupt, bool)>> = match blocking {
-            CheckException::Blocking => Box::new(
-                std::iter::once(self.interrupt_bus.recv().unwrap())
-                    .chain(self.interrupt_bus.try_iter()),
-            ),
-
-            CheckException::NonBlocking => Box::new(self.interrupt_bus.try_iter()),
-        };
-
-        for (interrupt, state) in iter {
-            if state {
-                self.devices.vicmgr.assert_interrupt(interrupt)
-            } else {
-                self.devices.vicmgr.clear_interrupt(interrupt)
-            }
+        macro_rules! check_exception {
+            ($iter:expr) => {{
+                for (interrupt, state) in $iter {
+                    if state {
+                        self.devices.vicmgr.assert_interrupt(interrupt)
+                    } else {
+                        self.devices.vicmgr.clear_interrupt(interrupt)
+                    }
+                }
+            }};
         }
+
+        match blocking {
+            CheckException::NonBlocking => check_exception!(self.interrupt_bus.try_iter()),
+            CheckException::Blocking => {
+                check_exception!(std::iter::once(self.interrupt_bus.recv().unwrap())
+                    .chain(self.interrupt_bus.try_iter()))
+            }
+        };
 
         if self.devices.vicmgr.fiq() {
             self.cpu.exception(Exception::FastInterrupt);


### PR DESCRIPTION
The previous implementation had two issues: It didn't drain the interrupt bus, meaning only one item could be polled from the interrupt bus per cycle.  That probably wasn't actually a problem, but isn't all that accurate.  The more major one is that previously, if there was no update on the bus, we'd skip the part where we query the VIC.  This doesn't work because the VIC's irq/fiq state can change without an event on the interrupt bus, by modifying the VIC's registers (e.g. intenable or softintenable).