### PR TITLE
Fix TX interrupt generation

### DIFF
--- a/src/devices/uart/device.rs
+++ b/src/devices/uart/device.rs
@@ -184,7 +184,7 @@ impl State {
             };
         }
 
-        update_interrupt!(self.interrupts.tx, self.tx_int_asserted, 0b1000);
+        update_interrupt!(self.interrupts.tx, self.tx_int_asserted, 0b0100);
         update_interrupt!(self.interrupts.rx, self.rx_int_asserted, 0b0010);
         update_interrupt!(self.interrupts.combo, self.combo_int_asserted, 0b1111);
     }


### PR DESCRIPTION
Our code was failing only in the emulator, since the emulator only appeared to generate the combo interrupt, not the tx interrupt. Turns out this is because the bitmask was wrong.

Thank you so much for writing this by the way! It has saved us hours upon hours in the lab.